### PR TITLE
feat: allow configuring the path of the openapi json spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,14 @@ export const swagger =
             version = '4.18.2',
             excludeStaticFile = true,
             path = '/swagger' as Path,
+            specPathname = 'json',
             exclude = []
         }: ElysiaSwaggerConfig<Path> = {
             documentation: {},
             version: '4.18.2',
             excludeStaticFile: true,
             path: '/swagger' as Path,
+            specPathname: 'json',
             exclude: []
         }
     ) =>
@@ -32,6 +34,10 @@ export const swagger =
             description: 'Developement documentation',
             version: '0.0.0',
             ...documentation.info
+        }
+        
+        if (specPathname.startsWith('/')) {
+            specPathname = specPathname.slice(1)
         }
 
         app.get(path, (context) => {
@@ -58,7 +64,7 @@ export const swagger =
     <script>
         window.onload = () => {
             window.ui = SwaggerUIBundle({
-                url: '${path}/json',
+                url: '${path}/${specPathname}',
                 dom_id: '#swagger-ui',
             });
         };
@@ -73,7 +79,7 @@ export const swagger =
             )
         }).route(
             'GET',
-            `${path}/json`,
+            `${path}/${specPathname}`,
             (context) =>
                 ({
                     openapi: '3.0.3',

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,14 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      */
     path?: Path
     /**
+     * The pathname for the OpenAPI spec, which will be appended to the path option.
+     * 
+     * @example 'openapi.json' => '/swagger/openapi.json'
+     *
+     * @default 'json'
+     */
+    specPathname?: string
+    /**
      * Paths to exclude from Swagger endpoint
      *
      * @default []

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -65,4 +65,17 @@ describe('Swagger', () => {
         const res = await app.handle(req('/v2/swagger'))
         expect(res.status).toBe(200)
     })
+
+    it('use custom spec path', async () => {
+        const app = new Elysia().use(
+            swagger({
+                path: '/v2/swagger',
+                specPathname: 'openapi.json'
+            })
+        )
+
+        const res = await app.handle(req('/v2/swagger/openapi.json'))
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-type')).toContain('application/json')
+    })
 })


### PR DESCRIPTION
This PR allows configuring the route of the JSON specification. It was previously hardcoded to `{path}/json`.

