### PR TITLE
Fix: Swagger Component Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,13 @@
     "release": "npm run build && npm run test && npm publish --access public"
   },
   "peerDependencies": {
-    "elysia": ">= 0.6.0-alpha.3"
+    "elysia": ">= 0.6.10"
   },
   "devDependencies": {
+    "@types/lodash.clonedeep": "^4.5.7",
     "@types/node": "^20.1.4",
     "bun-types": "^0.7.0",
-    "elysia": "^0.6.0-alpha.4",
+    "elysia": "^0.6.10",
     "eslint": "^8.40.0",
     "rimraf": "4.3",
     "typescript": "^5.0.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ export const swagger =
                         exclude: Array.isArray(exclude) ? exclude : [exclude]
                     }),
                     components: {
-                        schemas: app.meta.defs
+                        ...documentation.components
                     }
                 } satisfies OpenAPIV3.Document
             },


### PR DESCRIPTION

This pull request addresses an issue where the Swagger plugin for ElysiaJS was not effectively merging custom components provided at the application level.

Example of the problem:

```typescript
export const swaggerConfig: ElysiaSwaggerConfig = {
  documentation: {
    info: {
      title: "Endpoint Documentation",
      version: "1.0.0",
      description: "A very good description.",
    },
    components: {
      schemas: {
        User: {
          description: "string",
        },
      },
      securitySchemes: {
        JwtAuth: {
          type: "http",
          scheme: "bearer",
          bearerFormat: "JWT",
          description: "Enter JWT Bearer token **_only_**",
        },
      },
    },
  },
};
``;
``` 

Would result on a /swagger/json like this:
```
{
  "openapi": "3.0.3",
  "info": {
    "title": "Endpoint Documentation",
    "description": "A very good description.",
    "version": "1.0.0"
  },
  "components": {
    "schemas": {
    } ❌  Wheres our schema?
    ❌  Where's our securitySchemes?
  },
  "paths": {
  // rest of json
  },
``` 


With this fix, the plugin now correctly merges the user-defined components from the documentation configuration with the default schemas from app.meta.defs. This ensures that all user-defined Swagger components are accurately reflected in the generated documentation.

```
{
  "openapi": "3.0.3",
  "info": {
    "title": "Endpoint Documentation",
    "description": "A very good description.",
    "version": "1.0.0"
  "components": {
    "schemas": { ✅  Schema is present
      "User": {
        "description": "string"
      }
    },
    "securitySchemes": { ✅  securitySchemes is present
      "JwtAuth": {
        "type": "http",
        "scheme": "bearer",
        "bearerFormat": "JWT",
        "description": "Enter JWT Bearer token **_only_**"
      }
    }
  },
  "paths": {
  // rest of json
  },
```

