### PR TITLE
feat: handle nullish response types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,6 +44,9 @@ const mapTypesResponse = (
               required: string[]
           }
 ) => {
+    if (typeof schema === 'object'
+        && ['void', 'undefined', 'null'].includes(schema.type)) return;
+
     const responses: Record<string, OpenAPIV3.MediaTypeObject> = {}
 
     for (const type of types)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 import { swagger } from '../src'
 
 import { describe, expect, it } from 'bun:test'
@@ -64,5 +64,50 @@ describe('Swagger', () => {
 
         const res = await app.handle(req('/v2/swagger'))
         expect(res.status).toBe(200)
+    })
+
+    it('should not return content response when using Void type', async () => {
+        const app = new Elysia().use(
+            swagger())
+            .get('/void', () => {}, {
+                response: { 204: t.Void({
+                    description: 'Void response'
+            })}});
+
+        const res = await app.handle(req('/swagger/json'))
+        expect(res.status).toBe(200)
+        const response = await res.json();
+        expect(response.paths['/void'].get.responses['204'].description).toBe('Void response');
+        expect(response.paths['/void'].get.responses['204'].content).toBeUndefined();
+    })
+
+    it('should not return content response when using Undefined type', async () => {
+        const app = new Elysia().use(
+            swagger())
+            .get('/undefined', () => undefined, {
+                response: { 204: t.Undefined({
+                    description: 'Undefined response'
+            })}});
+
+        const res = await app.handle(req('/swagger/json'))
+        expect(res.status).toBe(200)
+        const response = await res.json();
+        expect(response.paths['/undefined'].get.responses['204'].description).toBe('Undefined response');
+        expect(response.paths['/undefined'].get.responses['204'].content).toBeUndefined();
+    })
+
+    it('should not return content response when using Null type', async () => {
+        const app = new Elysia().use(
+            swagger())
+            .get('/null', () => null, {
+                response: { 204: t.Null({
+                    description: 'Null response'
+            })}});
+
+        const res = await app.handle(req('/swagger/json'))
+        expect(res.status).toBe(200)
+        const response = await res.json();
+        expect(response.paths['/null'].get.responses['204'].description).toBe('Null response');
+        expect(response.paths['/null'].get.responses['204'].content).toBeUndefined();
     })
 })


### PR DESCRIPTION
This merge request addresses an issue that was wrongly opened in the elysia repository: https://github.com/elysiajs/elysia/issues/124

Using responses types like `t.Void()`, `t.Undefined()` or `t.Null()` means that in fact there will be no content in the response.
It could happen in a scenario of status code 204, when no respose is expected.

But current behaviour is breaking the view, since it generates a response with a content that is not acceptable by swagger:

An example:
Code:
```javascript
{
    body: "ActivationUserRequest",
    response: {
      200: t.Void({
        description: "User account was activated successfully",
      }),
      404: t.Void({
        description: "Pending account confirmation was not found",
      }),
      409: t.Void({
        description: "Account was already confirmed",
      }),
    },
    detail: {
      description:
        "Activate a user account based on previous secret that was sent by email",
      tags: ["User"],
      summary: "Activate a user account",
    },
  }
```
Screen with current behavior:
![image](https://github.com/elysiajs/elysia-swagger/assets/12190451/062a4539-748b-4a6a-b279-975dccd38a11)
Screen with desirable behaviour:
![image](https://github.com/elysiajs/elysia-swagger/assets/12190451/8e1ee699-eb89-4e0b-a61b-b4b83ffc468d)
