### PR TITLE
Point package.json "types" field to generated .d.ts instead of raw .ts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@ jest.config.js
 nodemon.json
 
 example
+src
 tests
 test
 CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "import": "./dist/index.js",
     "default": "./dist/index.js"
   },
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "keywords": [
     "elysia",
     "swagger"


### PR DESCRIPTION
The current config results in the dependent package compiling this package, which works in most cases but can fail if the dependent package has an incompatible `tsconfig.json`, e.g. by applying stricter options such as `exactOptionalPropertyTypes`.

This PR should bring the package in-line with the standard way of doing this, making sure it works for all `tsconfig.json` settings. It looks like a similar change was already made in the main `elysia` package as part of [this commit](https://github.com/elysiajs/elysia/commit/8c8ffa53ef5952f1f4613c4f40f197adee323457).