### PR TITLE
fix: typo in default documentation description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export const swagger =
                     ...documentation,
                     info: {
                         title: 'Elysia Documentation',
-                        description: 'Developement documentation',
+                        description: 'Development documentation',
                         version: '0.0.0',
                         ...documentation.info
                     }


### PR DESCRIPTION
Hi, I fixed a veeery slight typo in the default documentation description. I can't help but I notice it too much lol. Thanks