### PR TITLE
chore: Update Swagger-UI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export const swagger =
     <Path extends string = '/swagger'>(
         {
             documentation = {},
-            version = '5.7.2',
+            version = '5.9.0',
             excludeStaticFile = true,
             path = '/swagger' as Path,
             exclude = [],
@@ -24,7 +24,7 @@ export const swagger =
             autoDarkMode = true
         }: ElysiaSwaggerConfig<Path> = {
             documentation: {},
-            version: '5.7.2',
+            version: '5.9.0',
             excludeStaticFile: true,
             path: '/swagger' as Path,
             exclude: [],


### PR DESCRIPTION
Hi! This PR bumps the default Swagger-UI version from 5.7.2 to 5.9.0.