### PR TITLE
Fixed missin JavaScriptTypeBuilder import

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ bun add @elysiajs/swagger
 
 ## Example
 ```typescript
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 import { swagger } from '@elysiajs/swagger'
 
 const app = new Elysia()


### PR DESCRIPTION
Readme example is missing an import of t:JavaScriptTypeBuilder and does not work copy-pasted to a new project.