### PR TITLE
use relative path to swagger json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,11 +46,11 @@ export const swagger =
             ...documentation.info
         }
 
-        const pathWithPrefix = `${app.config.prefix}${path}`
+        const relativePath = path.startsWith('/') ? path.slice(1) : path
 
         app.get(path, () => {
             const combinedSwaggerOptions = {
-                url: `${pathWithPrefix}/json`,
+                url: `${relativePath}/json`,
                 dom_id: '#swagger-ui',
                 ...swaggerOptions
             }


### PR DESCRIPTION
I have a reverse proxy which serves my Elysia API at a subpath and it causes the swagger UI to fail loading the swagger JSON. Using relative URL fixes that.