### PR TITLE
add exclude options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export const swagger =
             swaggerOptions = {},
             theme = `https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`,
             autoDarkMode = true,
-            excludeOptions = true
+            excludeMethods = ['OPTIONS']
         }: ElysiaSwaggerConfig<Path> = {
             documentation: {},
             version: '5.9.0',
@@ -31,7 +31,7 @@ export const swagger =
             exclude: [],
             swaggerOptions: {},
             autoDarkMode: true,
-            excludeOptions: true
+            excludeMethods: ['OPTIONS']
         }
     ) =>
     (app: Elysia) => {
@@ -132,7 +132,7 @@ export const swagger =
                 totalRoutes = routes.length
 
                 routes.forEach((route: InternalRoute) => {
-                    if (excludeOptions && route.method === 'OPTIONS') return
+                    if (excludeMethods.includes(route.method)) return
                     
                     registerSchemaPath({
                         schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ export const swagger =
             exclude = [],
             swaggerOptions = {},
             theme = `https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`,
-            autoDarkMode = true
+            autoDarkMode = true,
+            excludeOptions = true
         }: ElysiaSwaggerConfig<Path> = {
             documentation: {},
             version: '5.9.0',
@@ -29,7 +30,8 @@ export const swagger =
             path: '/swagger' as Path,
             exclude: [],
             swaggerOptions: {},
-            autoDarkMode: true
+            autoDarkMode: true,
+            excludeOptions: true
         }
     ) =>
     (app: Elysia) => {
@@ -130,6 +132,8 @@ export const swagger =
                 totalRoutes = routes.length
 
                 routes.forEach((route: InternalRoute) => {
+                    if (excludeOptions && route.method === 'OPTIONS') return
+                    
                     registerSchemaPath({
                         schema,
                         hook: route.hooks,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
     autoDarkMode?: boolean
 
     /**
-     * Exclude OPTIONS method from Swagger
+     * Exclude methods from Swagger
      */
-    excludeOptions?: boolean
+    excludeMethods?: string[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,4 +71,9 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      * Using poor man dark mode 😭
      */
     autoDarkMode?: boolean
+
+    /**
+     * Exclude OPTIONS method from Swagger
+     */
+    excludeOptions?: boolean
 }


### PR DESCRIPTION
This gets rid of options displaying in the generated swagger, useful when using for example the CORS plugin when you have several options routes. Note: by default I set it to true as I believe very few people would want CORS in their swagger.