### PR TITLE
fix: update scalar to v1.13.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ export const swagger =
     <Path extends string = '/swagger'>(
         {
             provider = 'scalar',
-            scalarVersion = '1.13.0',
+            scalarVersion = 'latest',
+            scalarCDN = '',
             scalarConfig = {},
             documentation = {},
             version = '5.9.0',
@@ -32,7 +33,8 @@ export const swagger =
             excludeMethods = ['OPTIONS']
         }: ElysiaSwaggerConfig<Path> = {
             provider: 'scalar',
-            scalarVersion: '1.12.5',
+            scalarVersion: 'latest',
+            scalarCDN: '',
             scalarConfig: {},
             documentation: {},
             version: '5.9.0',
@@ -93,7 +95,7 @@ export const swagger =
                           stringifiedSwaggerOptions,
                           autoDarkMode
                       )
-                    : ScalarRender(scalarVersion, scalarConfiguration),
+                    : ScalarRender(scalarVersion, scalarConfiguration, scalarCDN),
                 {
                     headers: {
                         'content-type': 'text/html; charset=utf8'

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export const swagger =
     <Path extends string = '/swagger'>(
         {
             provider = 'scalar',
-            scalarVersion = '1.12.5',
+            scalarVersion = '1.13.0',
             scalarConfig = {},
             documentation = {},
             version = '5.9.0',

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -1,27 +1,31 @@
 import scalarElysiaTheme from './theme'
 import type { ReferenceConfiguration } from './types'
 
-export const ScalarRender = (version: string, config: ReferenceConfiguration) => `<!doctype html>
-<html>
-  <head>
-    <title>API Reference</title>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1" />
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
-    <style>
-      ${config.customCss ?? scalarElysiaTheme}
-    </style>
-  </head>
-  <body>
-    <script
-      id="api-reference"
-      data-url="${config.spec?.url}"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@${version}/dist/browser/standalone.min.js"></script>
-  </body>
-</html>`
+export const ScalarRender = (version: string, config: ReferenceConfiguration, scalarCDN: string) => {
+  const overrideScalarCDN = scalarCDN ? scalarCDN : `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${version}/dist/browser/standalone.min.js`
+
+  return `<!doctype html>
+    <html>
+      <head>
+        <title>API Reference</title>
+        <meta charset="utf-8" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1" />
+        <style>
+          body {
+            margin: 0;
+          }
+        </style>
+        <style>
+          ${config.customCss ?? scalarElysiaTheme}
+        </style>
+      </head>
+      <body>
+        <script
+          id="api-reference"
+          data-url="${config.spec?.url}"></script>
+        <script src="${overrideScalarCDN}"></script>
+      </body>
+    </html>`
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,14 +24,20 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
     /**
      * Version to use for Scalar cdn bundle
      *
-     * @default '1.12.5'
+     * @default 'latest'
      * @see https://github.com/scalar/scalar
      */
     scalarVersion?: string
     /**
-     * Scalar configuration to customize scalar
+     * Optional override to specifying the path for the Scalar bundle
      *
-     * @default '1.12.5'
+     * @default ''
+     * @see https://github.com/scalar/scalar
+     */
+    scalarCDN?: string
+    /**
+     * Scalar configuration to customize scalar
+     *'
      * @see https://github.com/scalar/scalar
      */
     scalarConfig?: ReferenceConfiguration


### PR DESCRIPTION
lot's of great fixes in v1.13.0!

```
97cd84e9: feat: client ignore list
5dac9c51: fix: open section on search result click
0e0f34b3: fix: cleanup safari bugs
7582e82a: fix: classic layout stylings
d5d55407: feat: expose dark mode light mode property in config
7d502131: fix: add markdown rendering for body schema
3e7c4cf7: feat: add fetch examples
859977f8: feat: Add dynamic content type selection for request body
0b66933d: fix: declare theme font for buttons and fix regressed font weight
87ed7f01: fix: markdown second level margin issue
4513c725: feat: add intro flare for gradients
```

