### PR TITLE
Scalar CDN Option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export const swagger =
         {
             provider = 'scalar',
             scalarVersion = '1.12.5',
+            scalarCDN = "",
             scalarConfig = {},
             documentation = {},
             version = '5.9.0',
@@ -33,6 +34,7 @@ export const swagger =
         }: ElysiaSwaggerConfig<Path> = {
             provider: 'scalar',
             scalarVersion: '1.12.5',
+            scalarCDN: "",
             scalarConfig: {},
             documentation: {},
             version: '5.9.0',

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export const swagger =
                           stringifiedSwaggerOptions,
                           autoDarkMode
                       )
-                    : ScalarRender(scalarVersion, scalarConfiguration),
+                    : ScalarRender(scalarVersion, scalarConfiguration, scalarCDN),
                 {
                     headers: {
                         'content-type': 'text/html; charset=utf8'

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -22,7 +22,6 @@ export const ScalarRender = (version: string, config: ReferenceConfiguration, cd
     <script
       id="api-reference"
       data-url="${config.spec?.url}"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@${version}/dist/browser/standalone.min.js"></script>
     <script src="${cdn ? cdn:`https://cdn.jsdelivr.net/npm/@scalar/api-reference@${version}/dist/browser/standalone.min.js`}"></script>
 
   </body>

--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -1,7 +1,7 @@
 import scalarElysiaTheme from './theme'
 import type { ReferenceConfiguration } from './types'
 
-export const ScalarRender = (version: string, config: ReferenceConfiguration) => `<!doctype html>
+export const ScalarRender = (version: string, config: ReferenceConfiguration, cdn: string) => `<!doctype html>
 <html>
   <head>
     <title>API Reference</title>
@@ -23,5 +23,7 @@ export const ScalarRender = (version: string, config: ReferenceConfiguration) =>
       id="api-reference"
       data-url="${config.spec?.url}"></script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@${version}/dist/browser/standalone.min.js"></script>
+    <script src="${cdn ? cdn:`https://cdn.jsdelivr.net/npm/@scalar/api-reference@${version}/dist/browser/standalone.min.js`}"></script>
+
   </body>
 </html>`

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,17 +29,20 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      */
     scalarVersion?: string
     /**
-     * Version to use for Scalar cdn bundle
+     * Custom URL or path to locally hosted Scalar bundle 
      *
-     * @default '1.12.5'
-     * @see https://github.com/scalar/scalar
+     * Lease blank to use default jsdeliver.net CDN
+     *
+     * @default ''
+     * @example 'https://unpkg.com/@scalar/api-reference@1.13.10/dist/browser/standalone.js'
+     * @example '/public/standalone.js'
      */
     scalarCDN?: string
     /**
-     * Scalar CDN bundle url
+     * Scalar configuration to customize scalar
      *
-     * @default ''
-     * @example 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@$1.12.5/dist/browser/standalone.min.js'
+     * @default '1.12.5'
+     * @see https://github.com/scalar/scalar
      */
     scalarConfig?: ReferenceConfiguration
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,10 +29,17 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      */
     scalarVersion?: string
     /**
-     * Scalar configuration to customize scalar
+     * Version to use for Scalar cdn bundle
      *
      * @default '1.12.5'
      * @see https://github.com/scalar/scalar
+     */
+    scalarCDN?: string
+    /**
+     * Scalar CDN bundle url
+     *
+     * @default ''
+     * @example 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@$1.12.5/dist/browser/standalone.min.js'
      */
     scalarConfig?: ReferenceConfiguration
     /**


### PR DESCRIPTION
Currently the URL to the scalar bundle is hardcoded to the [jsdeliver.net](https://cdn.jsdelivr.net) CDN. This PR added an additional option (`scalarCDN`) so the URL to the scalar bundle can be explicitly set. This is useful if a user wishes to host the scalar bundle themselves. When the `scalarCDN` option is set, the `scalarVersion` is ignored.

This change maintains backwards compatibility, and users who have `scalarVersion` set, will still get the scalar bundle from the default [jsdelivr.net](https://cdn.jsdelivr.net) CDN.

Example usage:

```javascript
const server = new Elysia().use(html).use(
  swagger({
    provider: "scalar",
    scalarCDN: "https://unpkg.com/@scalar/api-reference@1.13.10/dist/browser/standalone.js"
    //scalarCDN: "/public/standalone.min.js" //Served locally
  })
);
```