### PR TITLE
🔧 fix: doc get-route not rendering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export const swagger =
 
         app.get(
             path,
-            (() => {
+            () => {
                 const combinedSwaggerOptions = {
                     url: `${relativePath}/json`,
                     dom_id: '#swagger-ui',
@@ -108,7 +108,7 @@ export const swagger =
                         }
                     }
                 )
-            })()
+            }
         ).get(
             `${path}/json`,
             () => {


### PR DESCRIPTION
Little fix in the documentation get-route
Should render properly on the browser

Let me know if more is needed!

Fixes #98 