### PR TITLE
fix: use `type` variable since `rest.type` is always undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,9 +196,9 @@ export const registerSchemaPath = ({
                             description: rest.description as any,
                             content: mapTypesResponse(
                                 contentTypes,
-                                rest.type === 'object' || rest.type === 'array'
+                                type === 'object' || type === 'array'
                                     ? ({
-                                          type: rest.type,
+                                          type,
                                           properties,
                                           items: value.items,
                                           required


### PR DESCRIPTION
You can see below that `type` is removed from `rest` using the destructure syntax.

https://github.com/elysiajs/elysia-swagger/blob/12ec0e11d1a10443b1d78f26c6771022335b6825/src/utils.ts#L182-L208