### PR TITLE
Move parameters schema keywords location

### DIFF
--- a/example/plugin.ts
+++ b/example/plugin.ts
@@ -44,7 +44,7 @@ export const plugin = new Elysia({
     })
     .post(
         '/json/:id',
-        ({ body, params: { id }, query: { name } }) => ({
+        ({ body, params: { id }, query: { name, email, } }) => ({
             ...body,
             id
         }),
@@ -52,6 +52,22 @@ export const plugin = new Elysia({
             body: 'sign',
             params: t.Object({
                 id: t.Numeric()
+            }),
+            query: t.Object({
+                name: t.String(),
+                email: t.String({
+                    description: 'sample email description',
+                    format: 'email',
+                    examples: ['test@test.com']
+                }),
+                birthday: t.String({
+                    description: 'sample birthday description',
+                    pattern: '\\d{4}-\\d{2}-\\d{2}',
+                    minLength: 10,
+                    maxLength: 10,
+                    examples: ['2024-01-01']
+                }),
+                gender: t.Union([t.Literal('M'), t.Literal('F')])
             }),
             response: {
                 200: t.Object(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,11 +25,11 @@ export const mapProperties = (
         else throw new Error(`Can't find model ${schema}`)
 
     return Object.entries(schema?.properties ?? []).map(([key, value]) => {
-        const { type: valueType = undefined, description, examples, ...schemaProperties } = value as any
+        const { type: valueType = undefined, description, examples, ...schemaKeywords } = value as any
         return {
             // @ts-ignore
             description, examples,
-            schema: { type: valueType, ...schemaProperties },
+            schema: { type: valueType, ...schemaKeywords },
             in: name,
             name: key,
             // @ts-ignore

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,11 +25,11 @@ export const mapProperties = (
         else throw new Error(`Can't find model ${schema}`)
 
     return Object.entries(schema?.properties ?? []).map(([key, value]) => {
-        const { type: valueType = undefined, ...rest } = value as any
+        const { type: valueType = undefined, description, examples, ...schemaProperties } = value as any
         return {
             // @ts-ignore
-            ...rest,
-            schema: { type: valueType },
+            description, examples,
+            schema: { type: valueType, ...schemaProperties },
             in: name,
             name: key,
             // @ts-ignore

--- a/test/validateSchema.test.ts
+++ b/test/validateSchema.test.ts
@@ -79,6 +79,5 @@ it('returns a valid Swagger/OpenAPI json config for many routes', async () => {
         )
 
     const res = await app.handle(req('/swagger/json')).then((x) => x.json())
-    console.log(res.paths['/json/{id}'].post.parameters)
     await SwaggerParser.validate(res).catch((err) => fail(err))
 })

--- a/test/validateSchema.test.ts
+++ b/test/validateSchema.test.ts
@@ -2,7 +2,7 @@ import { Elysia, t } from 'elysia'
 import SwaggerParser from '@apidevtools/swagger-parser'
 import { swagger } from '../src'
 
-import { describe, expect, it } from 'bun:test'
+import { it } from 'bun:test'
 import { fail } from 'assert'
 
 const req = (path: string) => new Request(`http://localhost${path}`)
@@ -27,17 +27,30 @@ it('returns a valid Swagger/OpenAPI json config for many routes', async () => {
         )
         .post(
             '/json/:id',
-            ({ body, params: { id }, query: { name } }) => ({
+            ({ body, params: { id }, query: { name, email, birthday } }) => ({
                 ...body,
                 id,
-                name
+                name,
+                email,
+                birthday
             }),
             {
                 params: t.Object({
                     id: t.String()
                 }),
                 query: t.Object({
-                    name: t.String()
+                    name: t.String(),
+                    email: t.String({
+                        description: 'sample email description',
+                        format: 'email'
+                    }),
+                    birthday: t.String({
+                        description: 'sample birthday description',
+                        pattern: '\\d{4}-\\d{2}-\\d{2}',
+                        minLength: 10,
+                        maxLength: 10
+                    }),
+
                 }),
                 body: t.Object({
                     username: t.String(),
@@ -48,7 +61,17 @@ it('returns a valid Swagger/OpenAPI json config for many routes', async () => {
                         username: t.String(),
                         password: t.String(),
                         id: t.String(),
-                        name: t.String()
+                        name: t.String(),
+                        email: t.String({
+                            description: 'sample email description',
+                            format: 'email'
+                        }),
+                        birthday: t.String({
+                            description: 'sample birthday description',
+                            pattern: '\\d{4}-\\d{2}-\\d{2}',
+                            minLength: 10,
+                            maxLength: 10
+                        }),
                     },
                     { description: 'sample description 3' }
                 )
@@ -56,5 +79,6 @@ it('returns a valid Swagger/OpenAPI json config for many routes', async () => {
         )
 
     const res = await app.handle(req('/swagger/json')).then((x) => x.json())
+    console.log(res.paths['/json/{id}'].post.parameters)
     await SwaggerParser.validate(res).catch((err) => fail(err))
 })


### PR DESCRIPTION
- resolves #102
- Leave `description` and `examples` as parameter keywords, while move others to schema keywords. Based on:
  - https://swagger.io/specification/#parameter-object 
  - https://swagger.io/docs/specification/data-models/keywords/
  - https://swagger.io/docs/specification/describing-parameters/
- Added simple example and testing