### PR TITLE
bugfix(accept external swagger paths)

### DIFF
--- a/example/index3.ts
+++ b/example/index3.ts
@@ -1,0 +1,60 @@
+import { Elysia, InternalRoute } from 'elysia'
+import { swagger } from '../src/index'
+import { plugin } from './plugin'
+import { registerSchemaPath } from '../src/utils'
+
+const app = new Elysia()
+    .use(
+        swagger({
+            provider: 'scalar',
+            documentation: {
+                info: {
+                    title: 'Elysia Scalar',
+                    version: '0.8.1'
+                },
+                tags: [
+                    {
+                        name: 'Test',
+                        description: 'Hello'
+                    }
+                ],
+                paths:  { 
+                    "/b/": {
+                        get: {
+                          operationId: "getB",
+                          summary: "Ping Pong B",
+                          description: "Lorem Ipsum Dolar",
+                          tags: [ "Test" ],
+                          responses: {
+                            "200": {
+                                description: "test"
+                            },
+                          },
+                        },
+                      },
+                },
+                components: {
+                    schemas: {
+                        User: {
+                            description: 'string'
+                        }
+                    },
+                    securitySchemes: {
+                        JwtAuth: {
+                            type: 'http',
+                            scheme: 'bearer',
+                            bearerFormat: 'JWT',
+                            description: 'Enter JWT Bearer token **_only_**'
+                        }
+                    }
+                }
+            },
+            swaggerOptions: {
+                persistAuthorization: true
+            }
+        })
+    )
+    .use(plugin)
+    .listen(3000)
+
+console.log(app.rsaoutes)

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,10 +143,12 @@ export const swagger =
                             ...documentation.info
                         }
                     },
-                    paths: filterPaths(schema, {
+                    paths: {...filterPaths(schema, {
                         excludeStaticFile,
                         exclude: Array.isArray(exclude) ? exclude : [exclude]
-                    }),
+                        }),
+                        ...documentation.paths
+                    },
                     components: {
                         ...documentation.components,
                         schemas: {


### PR DESCRIPTION
This PR resolves an issue related to path options.
The reason as to why is the following scenario:
I use trpc with Elysia.js, my goal is now to include Swagger documentation of that process.
Below is my personal usecase / way as in how I generate the trpc documentation and how I use it.

```ts
import { trpc } from "@elysiajs/trpc";
import { Elysia } from "elysia";
import { appRouter } from "./router/router";
import { swagger } from "@elysiajs/swagger";
import {
    generateOpenApiDocument,
} from "trpc-openapi";

export const openApiDocument = generateOpenApiDocument(appRouter, {
  title: "tRPC OpenAPI",
  version: "1.0.0",
  baseUrl: "http://localhost:3000",
});

const swaggerExec = swagger({
  documentation: {
    paths: openApiDocument.paths,
  },
});

const app = new Elysia()
  .use(
    trpc(appRouter, {
      endpoint: "/trpc",
      createContext: (args) => {
        console.log(args);
        return {};
      },
    })
  )
  .use(swaggerExec)
  .listen(3000);

console.log(
  `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`
);
```