### PR TITLE
feature: exclude tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ export const swagger =
             swaggerOptions = {},
             theme = `https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`,
             autoDarkMode = true,
-            excludeMethods = ['OPTIONS']
+            excludeMethods = ['OPTIONS'],
+            excludeTags = []
         }: ElysiaSwaggerConfig<Path> = {
             provider: 'scalar',
             scalarVersion: 'latest',
@@ -43,7 +44,8 @@ export const swagger =
             exclude: [],
             swaggerOptions: {},
             autoDarkMode: true,
-            excludeMethods: ['OPTIONS']
+            excludeMethods: ['OPTIONS'],
+            excludeTags: []
         }
     ) =>
     (app: Elysia) => {
@@ -136,6 +138,7 @@ export const swagger =
                     openapi: '3.0.3',
                     ...{
                         ...documentation,
+                        tags: (documentation?.tags as {name: string; description: string}[])?.filter((tag) => !excludeTags?.includes(tag?.name)),
                         info: {
                             title: 'Elysia Documentation',
                             description: 'Development documentation',

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export const swagger =
                     openapi: '3.0.3',
                     ...{
                         ...documentation,
-                        tags: (documentation?.tags as {name: string; description: string}[])?.filter((tag) => !excludeTags?.includes(tag?.name)),
+                        tags: documentation.tags?.filter((tag) => !excludeTags?.includes(tag?.name)),
                         info: {
                             title: 'Elysia Documentation',
                             description: 'Development documentation',

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,4 +111,9 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      * Exclude methods from Swagger
      */
     excludeMethods?: string[]
+
+    /**
+     * Exclude tags from Swagger or Scalar
+     */
+    excludeTags?: string[]
 }


### PR DESCRIPTION
Hi everyone I added a new parameter to exclude tags. Currently we can exclude the endpoints but we can't exclude tags. Example: https://api.exchangeratesapi.net/docs