### PR TITLE
Add Support for app.all()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,12 +109,29 @@ export const swagger = async <Path extends string = '/swagger'>(
 		const routes = app.getGlobalRoutes() as InternalRoute[]
 
 		if (routes.length !== totalRoutes) {
+			const ALLOWED_METHODS = ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE']
 			totalRoutes = routes.length
 			
 			routes.forEach((route: InternalRoute) => {
 				if (route.hooks?.detail?.hide === true) return
 				// TODO: route.hooks?.detail?.hide !== false  add ability to hide: false to prevent excluding
 				if (excludeMethods.includes(route.method)) return
+				if (ALLOWED_METHODS.includes(route.method) === false && route.method !== 'ALL') return
+
+				if (route.method === 'ALL') {
+					ALLOWED_METHODS.forEach((method) => {
+						registerSchemaPath({
+							schema,
+							hook: route.hooks,
+							method,
+							path: route.path,
+							// @ts-ignore
+							models: app.definitions?.type,
+							contentType: route.hooks.type
+						})
+					})
+					return
+				}
 
 				registerSchemaPath({
 					schema,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -219,4 +219,31 @@ describe('Swagger', () => {
 		expect(response.paths['/public']).not.toBeUndefined();
 		expect(response.paths['/hidden']).toBeUndefined();
 	})
+
+	it('should expand .all routes', async () => {
+		const app = new Elysia().use(swagger())
+			.all("/all", "woah")
+
+		await app.modules
+
+		const res = await app.handle(req('/swagger/json'))
+		expect(res.status).toBe(200)
+		const response = await res.json()
+		expect(Object.keys(response.paths['/all'])).toBeArrayOfSize(8)
+	})
+
+	it('should hide routes that are invalid', async () => {
+		const app = new Elysia().use(swagger())
+			.get("/valid", "ok")
+			.route("LOCK", "/invalid", "nope")
+
+		await app.modules
+
+		const res = await app.handle(req('/swagger/json'))
+		expect(res.status).toBe(200)
+		const response = await res.json()
+		expect(response.paths['/valid']).not.toBeUndefined();
+		expect(response.paths['/invalid']).toBeUndefined();
+
+	})
 })

--- a/test/validate-schema.test.ts
+++ b/test/validate-schema.test.ts
@@ -77,6 +77,7 @@ it('returns a valid Swagger/OpenAPI json config for many routes', async () => {
                 )
             }
         )
+        .route('LOCK', '/lock', () => 'locked')
 
     await app.modules
 


### PR DESCRIPTION
This adds support for `app.all()` by simply registering a path for each allowed method in the OpenAPI Specification.

(As a side effect, this will also filter out any method that's not in the specification.)

closes #47, closes #130 