### PR TITLE
fix: 🐛 prevent failed to fetch spec from URL error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,11 +62,13 @@ export const swagger = async <Path extends string = '/swagger'>(
 
 	const relativePath = path.startsWith('/') ? path.slice(1) : path
 
+	const openAPISpecUrl = relativePath === '' ? `/json` : `/${relativePath}/json`
+
 	const app = new Elysia({ name: '@elysiajs/swagger' })
 
 	app.get(path, function documentation() {
 		const combinedSwaggerOptions = {
-			url: `/${relativePath}/json`,
+			url: openAPISpecUrl,
 			dom_id: '#swagger-ui',
 			...swaggerOptions
 		}
@@ -83,7 +85,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		const scalarConfiguration: ReferenceConfiguration = {
 			spec: {
 				...scalarConfig.spec,
-				url: `/${relativePath}/json`
+				url: openAPISpecUrl
 			},
 			...scalarConfig
 		}


### PR DESCRIPTION
There was a regression introduced with **Fix nested path issue in Swagger and Scalar config #146** which was meant to fix #135, when `path` is either `"/"` or `""` it leads to `Failed to fetch spec from URL` or `ERR_NAME_NOT_RESOLVED` because the `url` becomes `"http://json/"`. 


I can create a new issue but it might address #151

I also noticed that `excludePaths` might not be working as intended for when `path` is either `"/"` or `""` but that's always been the behavior so I didn't address that.