### PR TITLE
Add type check in cloneHook

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,7 +106,8 @@ export const generateOperationId = (method: string, paths: string) => {
 
 const cloneHook = <T>(hook: T) => {
 	if (!hook) return
-
+	if (typeof hook === 'string') return hook
+	if (Array.isArray(hook)) return [...hook]
 	return { ...hook }
 }
 


### PR DESCRIPTION
Close #155.

Hooks might be strings and might be accidentally deconstructed in cloneHook. This will break schemas defined in models.

output of 1.1.4
```
"application/json": {
  "schema": {
    "0": "a",
    "1": "u",
    "2": "t",
    "3": "h",
    "4": ":",
    "5": ":",
    "6": "s",
    "7": "i",
    "8": "g",
    "9": "n"
  }
}
```
output of 1.1.3
```
"application/json": {
  "schema": {
    "$ref": "#/components/schemas/auth::sign"
  }
}
```
