### PR TITLE
The Next.js Swagger Plugin Route Problem Was Solved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export const swagger = async <Path extends string = '/swagger'>({
 		documentation = {},
 		version = '5.9.0',
 		excludeStaticFile = true,
-		path = slug + 'swagger' as Path,
+		path = 'swagger' as Path,
 		exclude = [],
 		swaggerOptions = {},
 		theme = `https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ import type { ElysiaSwaggerConfig } from './types'
  *
  * @see https://github.com/elysiajs/elysia-swagger
  */
-export const swagger = async <Path extends string = '/swagger'>(
-	{
+export const swagger = async <Path extends string = '/swagger'>({
+		slug = "/", //api/
 		provider = 'scalar',
 		scalarVersion = 'latest',
 		scalarCDN = '',
@@ -24,7 +24,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		documentation = {},
 		version = '5.9.0',
 		excludeStaticFile = true,
-		path = '/swagger' as Path,
+		path = slug + 'swagger' as Path,
 		exclude = [],
 		swaggerOptions = {},
 		theme = `https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`,
@@ -32,6 +32,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		excludeMethods = ['OPTIONS'],
 		excludeTags = []
 	}: ElysiaSwaggerConfig<Path> = {
+		slug: "/", // api/ -> Forexample
 		provider: 'scalar',
 		scalarVersion: 'latest',
 		scalarCDN: '',
@@ -39,7 +40,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		documentation: {},
 		version: '5.9.0',
 		excludeStaticFile: true,
-		path: '/swagger' as Path,
+		path: 'swagger' as Path,
 		exclude: [],
 		swaggerOptions: {},
 		autoDarkMode: true,
@@ -59,8 +60,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		version: '0.0.0',
 		...documentation.info
 	}
-
-	const relativePath = path.startsWith('/') ? path.slice(1) : path
+	const relativePath = (slug + path).startsWith('/') ? path.slice(1) : path
 
 	const app = new Elysia({ name: '@elysiajs/swagger' })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,9 +22,9 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      */
     provider?: 'scalar' | 'swagger-ui'
     /**
-     * Choose your provider, Scalar or Swagger UI
+     * Base route for framework integrations
      *
-     * @default 'scalar'
+     * @default '/'
      * @see https://github.com/scalar/scalar
      * @see https://github.com/swagger-api/swagger-ui
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      */
     provider?: 'scalar' | 'swagger-ui'
     /**
+     * Choose your provider, Scalar or Swagger UI
+     *
+     * @default 'scalar'
+     * @see https://github.com/scalar/scalar
+     * @see https://github.com/swagger-api/swagger-ui
+     */
+    slug?: string
+    /**
      * Version to use for Scalar cdn bundle
      *
      * @default 'latest'


### PR DESCRIPTION
#158 I added "slug" parameter to swagger plugin for getting base route from framework. Before swagger plugin couldn't get base route.

For example:
Next.js = its actually /api/swagger/json but swagger plugin tries get swagger.json from this path /swagger/json