### PR TITLE
fix: Wrongful generation of `Date` type

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -304,12 +304,12 @@ describe('Swagger', () => {
 				{
 					format: 'date',
 					type: 'string',
-					default: expect.any(String) // this is the correct syntax
+					default: expect.any(String)
 				},
 				{
 					format: 'date-time',
 					type: 'string',
-					default: expect.any(String) // this is the correct syntax
+					default: expect.any(String)
 				},
 				{
 					type: 'number'


### PR DESCRIPTION
This fixes that we're generating objects of type: `Date` which is not a valid OpenAPI data type [see docs](https://swagger.io/docs/specification/v3_0/data-models/data-types/).

I also added a test to verify that it works as expected.

Let me know if i should change anything