### PR TITLE
Fix path issue in Scalar config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		const scalarConfiguration: ReferenceConfiguration = {
 			spec: {
 				...scalarConfig.spec,
-				url: `${request.url}/json`
+				url: `${new URL(request.url).pathname.replace(/\/$/, "")}/json`
 			},
 			...scalarConfig,
 			// so we can showcase the elysia theme

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 
 	const app = new Elysia({ name: '@elysiajs/swagger' })
 
-	app.get(path, function documentation() {
+	app.get(path, function documentation({request}) {
 		const combinedSwaggerOptions = {
 			url: openAPISpecUrl,
 			dom_id: '#swagger-ui',
@@ -85,7 +85,7 @@ export const swagger = async <Path extends string = '/swagger'>(
 		const scalarConfiguration: ReferenceConfiguration = {
 			spec: {
 				...scalarConfig.spec,
-				url: openAPISpecUrl
+				url: `${request.url}/json`
 			},
 			...scalarConfig,
 			// so we can showcase the elysia theme


### PR DESCRIPTION
When using a prefix, the plugin tries to fetch the scalar config from an incorrect path as mentioned in issues #161, #183, #151 . This can be seen in the screenshots below.

This PR enables successful fetching of the Scalar config from the correct URL whether a prefix is used or not and even if the prefix is nested.

closes #161 
closes #183 
closes #151 
closes #157 

![elysia with prefix](https://github.com/user-attachments/assets/585be8c7-79e5-4185-b24c-096ba1bede15)
![Incorrect JSON path](https://github.com/user-attachments/assets/ed564eec-a544-4365-9faf-7dc344059720)

![No prefix](https://github.com/user-attachments/assets/8285f0b3-4a9e-4b96-b995-2d883d97ba71)
![No prefix on elysia](https://github.com/user-attachments/assets/66f0369c-445e-49ea-a2c7-5267becf8d1e)

![Elysia swagger with corrected path](https://github.com/user-attachments/assets/e30d76ac-d390-4f17-9145-37172cfa6943)
![nested prefix](https://github.com/user-attachments/assets/33d3a02a-47fe-4f67-9e2e-5cea54bb84af)



