### PR TITLE
fix: Prevent default theme from overriding custom themes  

### DIFF
--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -1,6 +1,6 @@
 import { elysiajsTheme } from '@scalar/themes'
-import type { OpenAPIV3 } from 'openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types'
+import type { OpenAPIV3 } from 'openapi-types'
 
 export const ScalarRender = (
     info: OpenAPIV3.InfoObject,
@@ -29,7 +29,7 @@ export const ScalarRender = (
       }
     </style>
     <style>
-      ${config.customCss ?? elysiajsTheme}
+      ${config.customCss || config.theme ? config.customCss : elysiajsTheme}
     </style>
   </head>
   <body>


### PR DESCRIPTION
This PR fixes an issue where the default theme (`elysiajsTheme`) would override custom themes when `config.customCss` was not explicitly set to truly. 

#### Before
The default theme was applied whenever `config.customCss` was falsy (`null`, `undefined`, or `false`):  
```html
<style>
  ${config.customCss ?? elysiajsTheme}
</style>
```

#### After
Now, the default theme is only applied if **both** `config.customCss` and `config.theme` are falsy:  
```html
<style>
  ${config.customCss || config.theme ? config.customCss : elysiajsTheme}
</style>
```

#### Why?
This prevents the default theme from overriding a manually selected theme when `config.customCss` is falsy but `config.theme` is set.