### PR TITLE
fix: Fixed themes being overwritten by eliasyjsTheme

### DIFF
--- a/src/scalar/index.ts
+++ b/src/scalar/index.ts
@@ -29,7 +29,7 @@ export const ScalarRender = (
       }
     </style>
     <style>
-      ${config.customCss ?? elysiajsTheme}
+      ${config.theme ? (config.customCss ?? elysiajsTheme) : (config.customCss ?? "")}
     </style>
   </head>
   <body>


### PR DESCRIPTION
Fixed the issue mentioned in #194 which is caused by the native Scalar theme stylings being overridden by ``elysiajsTheme``. The fix consists of a check if a scalar theme was supplied and respectively disabling the elysiajs theme stylings.