### PR TITLE
Add support for `x-tagGroups` for Scalar Swagger Document generation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3 } from 'openapi-types'
-import type { ReferenceConfiguration } from '@scalar/types'
+import type { ReferenceConfiguration, TagGroup } from '@scalar/types'
 import type { SwaggerUIOptions } from './swagger/types'
 
 export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
@@ -8,11 +8,7 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      *
      * @see https://swagger.io/specification/v2/
      */
-    documentation?: Omit<
-        Partial<OpenAPIV3.Document>,
-        | 'x-express-openapi-additional-middleware'
-        | 'x-express-openapi-validation-strict'
-    >
+    documentation?: ElysiaSwaggerDocumentation
     /**
      * Choose your provider, Scalar or Swagger UI
      *
@@ -117,3 +113,15 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      */
     excludeTags?: string[]
 }
+
+interface ElysiaSwaggerDocumentation extends Omit<
+    Partial<OpenAPIV3.Document>,
+    | 'x-express-openapi-additional-middleware'
+    | 'x-express-openapi-validation-strict'
+> {
+    /**
+     * Group tags in Scalar UI using `x-tagGroups` property
+     */
+    'x-tagGroups'?: TagGroup[]
+}
+


### PR DESCRIPTION
## Abstract
This PR adds support for redoc's `x-tagGroups` [(Ref)](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups), which is supported by `Scalar` [(Reference)](https://github.com/scalar/scalar/blob/7e5d385ff5f43f39ca6264fdce6687f622e2d37e/documentation/openapi.md?plain=1#L90)  

### Example
```ts
new Elysia()
  .use(swagger({
    path: '/docs',
    documentation: {
      tags: [
        {
           name: 'two-factor',
           description: 'Allow users to manage their 2FA config'
        }, {
           name: 'password',
           description: 'User actions for changing their own password'
        }
      ],
      'x-tagGroups': [
        {
          name: 'user',
          tags: ['two-factor', 'password']
        }
      ]
    }
  })
```

The example code will generate `Scalar UI` like the following:  
![image](https://github.com/user-attachments/assets/7c49478f-be01-43cd-8242-31807168d977)
