### PR TITLE
feat: add rapidoc provider

### DIFF
--- a/example/index-rapidoc.ts
+++ b/example/index-rapidoc.ts
@@ -1,0 +1,55 @@
+import { Elysia, t } from 'elysia'
+import { swagger } from '../src/index'
+
+new Elysia({precompile: true})
+    .use(
+        swagger({
+            provider: 'rapidoc',
+            documentation: {
+                info: {
+                    title: 'Elysia Rapidoc',
+                    version: '1.0.0'
+                },
+                tags: [
+                    {
+                        name: 'Test',
+                        description: 'Hello'
+                    }
+                ],
+                components: {
+                    schemas: {
+                        User: {
+                            description: 'string'
+                        }
+                    },
+                    securitySchemes: {
+                        JwtAuth: {
+                            type: 'http',
+                            scheme: 'bearer',
+                            bearerFormat: 'JWT',
+                            description: 'Enter JWT Bearer token **_only_**'
+                        }
+                    }
+                }
+            },
+            rapidocConfig: {
+
+            }
+        })
+    )
+    .get('/ping', async () => {
+            return { pong: 'ping' }
+        },
+        {
+            response: {
+                200: t.Object({
+                    pong: t.String({ default: 'ping' })
+                })
+            }
+        }
+    )
+    .onStart(() => {
+        console.info(`🔥 http://localhost:3200/swagger`)
+    })
+    .listen(3200)
+

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "license": "MIT",
     "scripts": {
         "dev": "bun run --watch example/index.ts",
+        "dev-rapidoc": "bun run --watch example/index-rapidoc.ts",
         "test": "bun test && npm run test:node",
         "test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js",
         "build": "bun build.ts",

--- a/src/rapidoc/index.ts
+++ b/src/rapidoc/index.ts
@@ -1,0 +1,84 @@
+import type { OpenAPIV3 } from "openapi-types";
+
+/**
+ * Rapidoc Config
+ * @see https://rapidocweb.com/api.html
+ */
+export type RapidocConfig = Partial<{
+    specUrl: string
+    //
+    allowAdvancedSearch: boolean
+    allowSpecFileDownload: boolean
+    allowTry: boolean
+    defaultSchemaTab: 'schema'
+    fillRequestFieldsWithExample: boolean
+    gotoPath: string
+    headingText: string
+    infoDescriptionHeadingsInNavbar: boolean
+    layout: 'row' | 'column'
+    loadFonts: boolean
+    monoFont: string
+    navItemSpacing: 'default' | 'compact' | 'relaxed'
+    onNavTagClick: 'expand-collapse' | 'show-description'
+    persistAuth: boolean
+    renderStyle: 'read' | 'view' | 'focused'
+    responseAreaHeight: string
+    schemaDescriptionExpanded: boolean
+    schemaExpandLevel: number
+    schemaStyle: 'table'
+    showComponents: boolean
+    showCurlBeforeTry: boolean
+    showHeader: boolean
+    showInfo: boolean
+    showMethodInNavBar: 'as-colored-block'
+    sortEndpointsBy: 'path' | 'method' | 'summary' | 'none'
+    sortSchemas: boolean
+    sortTags: boolean
+    theme: 'light' | 'dark'
+    usePathInNavBar: boolean
+}>
+
+function kebab(str: string): string {
+    return str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? "-" : "") + $.toLowerCase())
+}
+
+function renderConfig(config: RapidocConfig): string {
+    const a: string[] = []
+    Object.keys(config).forEach((key) => {
+        a.push(`${kebab(key)}="${String(config[key as keyof RapidocConfig])}"`)
+    })
+    return a.join(' ')
+}
+
+export const RapidocRender = (
+    info: OpenAPIV3.InfoObject,
+    config: RapidocConfig,
+    cdn = 'https://unpkg.com/rapidoc/dist/rapidoc-min.js'
+) => `<!doctype html>
+<html>
+  <head>
+    <title>${info.title}</title>
+    <meta
+        name="description"
+        content="${info.description}"
+    />
+    <meta
+        name="og:description"
+        content="${info.description}"
+    />
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+    <script type="module" src="${cdn}" crossorigin></script>
+  </head>
+  <body>
+    <rapi-doc ${renderConfig(config)}></rapi-doc>
+  </body>
+</html>
+`

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIV3 } from 'openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types'
 import type { SwaggerUIOptions } from './swagger/types'
+import { RapidocConfig } from "./rapidoc";
 
 export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
     /**
@@ -19,8 +20,9 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      * @default 'scalar'
      * @see https://github.com/scalar/scalar
      * @see https://github.com/swagger-api/swagger-ui
+     * @see https://github.com/rapi-doc/RapiDoc
      */
-    provider?: 'scalar' | 'swagger-ui'
+    provider?: 'scalar' | 'swagger-ui' | 'rapidoc'
     /**
      * Version to use for Scalar cdn bundle
      *
@@ -47,6 +49,12 @@ export interface ElysiaSwaggerConfig<Path extends string = '/swagger'> {
      * @see https://github.com/scalar/scalar/blob/main/documentation/configuration.md
      */
     scalarConfig?: ReferenceConfiguration
+    /**
+     * Rapidoc configuration
+     *'
+     * @see https://rapidocweb.com/api.html
+     */
+    rapidocConfig?: RapidocConfig
     /**
      * Version to use for swagger cdn bundle
      *


### PR DESCRIPTION
## Abstract

This PR adds support for RapiDoc provider [(Ref)](https://rapidocweb.com)

## Example

See `example/index-rapidoc.ts`
Run `bun run dev-rapidoc`