### PR TITLE
Standalone Validators support, `modelname[]` in body fix and globalDefinitions complience fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { Elysia, type InternalRoute } from 'elysia'
+import { Elysia, TSchema, type InternalRoute } from 'elysia'
 
 import { SwaggerUIRender } from './swagger'
 import { ScalarRender } from './scalar'
@@ -130,7 +130,8 @@ export const swagger = <Path extends string = '/swagger'>({
 								path: route.path,
 								// @ts-ignore
 								models: app.getGlobalDefinitions?.().type,
-								contentType: route.hooks.type
+								contentType: route.hooks.type,
+								standaloneValidators: route.standaloneValidators
 							})
 						})
 					else
@@ -141,7 +142,8 @@ export const swagger = <Path extends string = '/swagger'>({
 							path: route.path,
 							// @ts-ignore
 							models: app.getGlobalDefinitions?.().type,
-							contentType: route.hooks.type
+							contentType: route.hooks.type,
+							standaloneValidators: route.standaloneValidators
 						})
 				})
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,15 @@ export const swagger = <Path extends string = '/swagger'>({
 				})
 			}
 
+			// @ts-ignore
+			const globalDefinitions = { ...app.getGlobalDefinitions?.().type }
+			// remove $id from globalDefinitions as it breaks OpenAPI compliance
+			Object.entries(globalDefinitions).map(([key, value]) => {
+				if (value.$id) {
+					delete globalDefinitions[key].$id
+				}
+			})
+
 			return {
 				openapi: '3.0.3',
 				...{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -353,7 +353,14 @@ export const registerSchemaPath = ({
 							required: true,
 							content: mapTypesResponse(
 								contentTypes,
-								typeof bodySchema === 'string'
+								typeof bodySchema === 'string' && bodySchema.slice(-2) === '[]'
+									? {
+										type: 'array',
+										items: {
+											$ref: `#/components/schemas/${bodySchema.slice(0, -2)}`
+										}
+									}
+								: typeof bodySchema === 'string'
 									? {
 											$ref: `#/components/schemas/${bodySchema}`
 										}

--- a/test/validate-schema.test.ts
+++ b/test/validate-schema.test.ts
@@ -16,15 +16,28 @@ it('returns a valid Swagger/OpenAPI json config for many routes', async () => {
         .get('/unpath/:id', ({ params: { id } }) => id, {
             response: t.String({ description: 'sample description' })
         })
+        .model({
+            thing: t.Object({
+                bar: t.String()
+            })
+        })
         .get(
             '/unpath/:id/:name/:age',
             ({ params: { id, name } }) => `${id} ${name}`,
             {
                 type: 'json',
                 response: t.String({ description: 'sample description' }),
-                params: t.Object({ id: t.String(), name: t.String() })
+                params: t.Object({ id: t.String(), name: t.String() }),
+                body: "thing[]"
             }
         )
+        .guard({
+            schema: "standalone",
+            body: t.Object({
+                foo: t.String()
+            }),
+            query: "thing"
+        })
         .post(
             '/json/:id',
             ({ body, params: { id }, query: { name, email, birthday } }) => ({


### PR DESCRIPTION
The main purpose of this PR is to add standaloneValidators support to elysia-swagger using `t.Composite` to merge schemas, fixing #218. `t.Intersection` was considered, but it seemed to generate much more complex schemas then was actually necessary

Of course, this wouldn't work with validator chains that don't make sense, like first checking that `body` is a `t.String()` in a standalone guard and then expecting it to be a `t.Object()` in a route, but those do not work in Elysia either. Currently, `t.Composite` ignores all non-object schemas when merging, so the resulting type for this example would be `t.Object()`. Alternative approach could be to check for non-object schemas in the validator chain and either throw an error or just return that schema to signal to the user that something is wrong, because most API's I assume expect objects, not plain values.

Along the way, this PR fixes `.model` support making it more spec compliant by deleting the $id property on the globalDefinitions and creating valid schemas for `body: "modelname[]"` definitions
The big test was updated to include all of these new behaviors