### PR TITLE
Fix for headers being overwritten by query

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -345,7 +345,7 @@ export function toOpenAPISchema(
 
 		// Handle header parameters
 		if (hooks.headers) {
-			const headers = unwrapReference(unwrapSchema(hooks.query, vendors), definitions)
+			const headers = unwrapReference(unwrapSchema(hooks.headers, vendors), definitions)
 
 			if (headers && headers.type === 'object' && headers.properties) {
 				const required = headers.required || []

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test'
-import { getPossiblePath } from '../src/openapi'
+import { Elysia, t } from 'elysia'
+import { getPossiblePath, toOpenAPISchema } from '../src/openapi'
 
 describe('OpenAPI utilities', () => {
 	it('getPossiblePath', () => {
@@ -10,5 +11,56 @@ describe('OpenAPI utilities', () => {
 			'/user/:user/name',
 			'/user/name'
 		])
+	})
+})
+
+describe('Convert Elysia routes to OpenAPI 3.0.3 paths schema', () => {
+	describe('with path, header, query and cookie params', () => {
+		const app = new Elysia().get('/', () => 'hi', {
+			response: t.String({ description: 'sample description' }),
+			headers: t.Object({
+				testheader: t.String()
+			}),
+			params: t.Object({
+				testparam: t.String()
+			}),
+			query: t.Object({
+				testquery: t.String()
+			}),
+			cookie: t.Cookie({
+				testcookie: t.String()
+			})
+		})
+
+		const {
+			paths: { ['/']: path }
+		} = toOpenAPISchema(app)
+
+		const parameters = path?.get?.parameters ?? []
+
+		it('includes all expected parameters', () => {
+			const names = parameters.map((p: any) => p.name)
+			expect(names).toEqual(
+				expect.arrayContaining([
+					'testheader',
+					'testparam',
+					'testquery',
+					'testcookie'
+				])
+			)
+			expect(names).toHaveLength(4)
+		})
+
+		it('marks each parameter with the correct OpenAPI parameter location', () => {
+			const map = Object.fromEntries(
+				parameters.map((p: any) => [p.name, p.in])
+			)
+			expect(map).toMatchObject({
+				testheader: 'header',
+				testparam: 'path',
+				testquery: 'query',
+				testcookie: 'cookie'
+			})
+		})
 	})
 })


### PR DESCRIPTION
This afternoon we noticed an issue where header validation was being overwritten by query validation. Specifically:

* When both header and query validation was defined, the query values overwrote the headers.
* When only headers were provided, they were ignored entirely.
* It appears in 1.4.* but not in 1.3.*.

This PR fixes the issue and adds targeted tests to prevent regression.

## Steps to replicate 

```ts
import { Elysia, t } from "elysia";
import openapi from "@elysiajs/openapi";

const app = new Elysia()
  .use(openapi())
  .get("/", () => "hello", {
    headers: t.Object({
      "test-header": t.String(),
    }),
    query: t.Object({
      page: t.String(),
      resultsPerPage: t.String(),
    }),
    response: t.String(),
  })
  .listen(3000);

console.log(
  `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`
);
```

```json
{
  "name": "app",
  "version": "1.0.50",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1",
    "dev": "bun run --watch src/index.ts"
  },
  "dependencies": {
    "elysia": "1.4.5"
    "@elysiajs/openapi": "1.4.2"
  },
  "devDependencies": {
    "bun-types": "latest"
  },
  "module": "src/index.js"
}
```

<img width="540" height="413" alt="image" src="https://github.com/user-attachments/assets/aa649ed7-802b-4ac2-959b-973b38834be7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenAPI generation to derive header parameters from the header schema, ensuring headers appear with in: "header" and proper required handling.

* **Tests**
  * Added integration test verifying parameter locations (header, path, query, cookie) in generated OpenAPI for Elysia routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->