### PR TITLE
[Regression] Re-enable regex support in excludePaths array

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -314,7 +314,11 @@ export function toOpenAPISchema(
 
 		if (
 			(excludeStaticFile && route.path.includes('.')) ||
-			excludePaths.includes(route.path) ||
+			excludePaths.some((excludedPath) =>
+				excludedPath instanceof RegExp
+					? excludedPath.test(route.path)
+					: excludedPath === route.path
+			) ||
 			excludeMethods.includes(method)
 		)
 			continue


### PR DESCRIPTION
After the OpenAPI refactor, I found two issues related to the `exclude` option:

1. **`exclude.methods` case sensitivity**  
   Previously, the `excludeMethods` array elements were provided in uppercase. After the refactor, in the implementation the path method is converted to lowercase before comparison with excluded elements, which broke the functionality.  
   This fix ensures that the provided array is normalized to lowercase as well, so users can supply `exclude.methods` in any case format.

2. **`exclude.paths` regex support**  
   According to the type definitions, `exclude.paths` should accept both strings and regular expressions. However, the implementation only handled string equality, ignoring regex patterns.  
   This PR adds proper handling for regex values.