### PR TITLE
🔧 fix: avoid error when using `exclude.tags` with an API without tags

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -320,7 +320,7 @@ export function toOpenAPISchema(
 			continue
 
 		const hooks: InputSchema & {
-			detail: Partial<OpenAPIV3.OperationObject>
+			detail?: Partial<OpenAPIV3.OperationObject>
 		} = route.hooks ?? {}
 
 		if (references?.length)
@@ -380,7 +380,7 @@ export function toOpenAPISchema(
 
 		if (
 			excludeTags &&
-			hooks.detail.tags?.some((tag) => excludeTags?.includes(tag))
+			hooks.detail?.tags?.some((tag) => excludeTags?.includes(tag))
 		)
 			continue
 


### PR DESCRIPTION
- closes #273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - OpenAPI generation now correctly excludes routes by specified tags.
  - Handles missing operation details gracefully to prevent errors during schema creation.

- Tests
  - Added coverage to verify route exclusion by tags in the OpenAPI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->