### PR TITLE
🔧 fix: `exclude.paths` is not working when using RegExp

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -314,7 +314,12 @@ export function toOpenAPISchema(
 
 		if (
 			(excludeStaticFile && route.path.includes('.')) ||
-			excludePaths.includes(route.path) ||
+			excludePaths.some(match => {
+				if (typeof match === 'string') {
+					return match === route.path
+				}
+				return match.exec(route.path);
+			}) ||
 			excludeMethods.includes(method)
 		)
 			continue

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -272,4 +272,27 @@ describe('Swagger', () => {
 		const response = await res.json()
 		expect(Object.keys(response.paths['/all'])).toBeArrayOfSize(8)
 	})
+
+	// https://github.com/elysiajs/elysia-openapi/issues/275
+	it('should exclude entry points excluded by `exclude.path` option', async () => {
+		const app = new Elysia()
+			.use(
+				openapi({
+					exclude: {
+						paths: [/^\/v1/, "/v2"],
+					},
+				})
+			)
+			.get("/", () => "index")
+			.get("/v1", () => "v1")
+			.get("/v1/foo", () => "v1")
+			.get("/v2", () => "v2")
+
+		await app.modules
+
+		const res = await app.handle(req('/openapi/json'))
+		expect(res.status).toBe(200)
+		const response = await res.json()
+		expect(Object.keys(response.paths)).toStrictEqual(["/"])
+	})
 })


### PR DESCRIPTION
- closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for regex-based path exclusions in OpenAPI generation alongside exact string matches, so you can flexibly control which routes appear in the generated spec.

* **Tests**
  * Added tests to confirm excluded paths—both regex patterns and exact strings—are omitted from the produced OpenAPI output, ensuring only intended routes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->