### PR TITLE
🎉 feat(scalar): support functions options

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -7,9 +7,13 @@ import { openapi, withHeaders } from '../src/index'
 const app = new Elysia()
 	.use(
 		openapi({
-			embedSchema: true,
 			mapJsonSchema: {
 				zod: z.toJSONSchema
+			},
+			scalar: {
+				onBeforeRequest: ({ request }) => {
+					console.info('onBeforeRequest', request.method, request.url)
+				}
 			}
 		})
 	)

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,7 @@ export interface ElysiaOpenAPIConfig<
 	 *'
 	 * @see https://github.com/scalar/scalar/blob/main/documentation/configuration.md
 	 */
-	scalar?: ApiReferenceConfiguration & {
+	scalar?: Partial<ApiReferenceConfiguration> & {
 		/**
 		 * Version to use for Scalar cdn bundle
 		 *


### PR DESCRIPTION
- closes #280

---

- Refines `scalar` option property to make all properties from `ApiReferenceConfiguration` optional
- To allow `scalar` option function properties I adapted the code from scalar core package `getScriptTags` function\
   Basically now instead of using a tag with a stringified json a script is generated with both static and function properties


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests are now logged (method and URL) before they are handled.
* **Refactor**
  * Streamlined how the API Reference scripts are injected, improving reliability of embedding and CDN loading.
  * Configuration for the API Reference is more flexible; most fields are now optional and support complex values (including arrays and functions) where applicable.
* **Chores**
  * Removed an obsolete schema-embedding option from the example configuration (no impact on routes or responses).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->