### PR TITLE
[#310] : [BUG] Handle schema references without full path prefix in toRef (@elysiajs/openapi : 1.4.12)

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -26,7 +26,11 @@ import { defineConfig } from 'tsup'
 export const capitalize = (word: string) =>
 	word.charAt(0).toUpperCase() + word.slice(1)
 
-const toRef = (name: string) => t.Ref(`#/components/schemas/${name}`)
+const toRef = (name: string) => t.Ref(
+	name.startsWith('#/')
+		? name
+		: `#/components/schemas/${name}`
+)
 
 const toOperationId = (method: string, paths: string) => {
 	let operationId = method.toLowerCase()
@@ -237,7 +241,7 @@ const normalizeSchemaReference = (
 
 	// Convert string reference to t.Ref node
 	// This allows string aliases to participate in schema composition
-	return t.Ref(schema)
+	return toRef(schema)
 }
 
 /**


### PR DESCRIPTION
explanation of the issue: #310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced OpenAPI reference handling to support both absolute and relative reference formats.
  * References are now consistently normalized, preserving already-qualified references and automatically prefixing others to the appropriate schema location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->