### PR TITLE
fix: include body schema in OpenAPI docs when parse is 'none'

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "@elysiajs/openapi",
-      "dependencies": {
-        "elysia": "https://pkg.pr.new/elysiajs/elysia@1637",
-      },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.0.0",
         "@scalar/types": "^0.2.13",

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -936,6 +936,17 @@ export function toOpenAPISchema(
 									schema: body
 								}
 								continue
+
+							case 'none':
+								// When parse is "none", include all common content types
+								// since the raw body could be any format
+								content['application/json'] = { schema: body }
+								content['application/x-www-form-urlencoded'] = {
+									schema: body
+								}
+								content['multipart/form-data'] = { schema: body }
+								content['text/plain'] = { schema: body }
+								continue
 						}
 					}
 

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -1276,4 +1276,32 @@ describe('OpenAPI > toOpenAPISchema', () => {
 			}
 		})
 	})
+
+	it('include body schema when parse is "none"', () => {
+		const app = new Elysia().post(
+			'/echo',
+			({ request }) => request,
+			{
+				body: t.Object({ input: t.String() }),
+				parse: 'none'
+			}
+		)
+
+		const schema = JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+		expect(schema.paths['/echo'].post.requestBody).toBeDefined()
+		expect(schema.paths['/echo'].post.requestBody.content).toBeDefined()
+		expect(
+			schema.paths['/echo'].post.requestBody.content['application/json']
+		).toBeDefined()
+		expect(
+			schema.paths['/echo'].post.requestBody.content['application/json'].schema
+		).toEqual({
+			type: 'object',
+			properties: {
+				input: { type: 'string' }
+			},
+			required: ['input']
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #1720

When using `parse: 'none'` to preserve raw request bodies, the body schema was being omitted from generated OpenAPI documentation.

## Problem

The issue was in the content type switch statement in `src/openapi.ts`. When `parse: 'none'` is set:
1. `hooks.parse` exists (the array contains the 'none' parser)
2. The code enters the `if (hooks.parse)` branch
3. The for loop iterates through parsers
4. `parser.fn === 'none'` doesn't match any case in the switch
5. `content` remains an empty object `{}`
6. `operation.requestBody.content` is set to empty

## Solution

Added a `case 'none':` that includes all common content types (application/json, application/x-www-form-urlencoded, multipart/form-data, text/plain) since the raw body could be any format.

## Testing

Added test case that verifies body schema is included when `parse: 'none'` is set.

```ts
it('include body schema when parse is "none"', () => {
    const app = new Elysia().post(
        '/echo',
        ({ request }) => request,
        {
            body: t.Object({ input: t.String() }),
            parse: 'none'
        }
    )
    // ... validates requestBody.content['application/json'] exists
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenAPI schema generation to support all common content types (application/json, application/x-www-form-urlencoded, multipart/form-data, text/plain) when the 'none' parser option is used.

* **Tests**
  * Added test coverage for the enhanced 'none' parser behavior in OpenAPI schema generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->