### PR TITLE
Prepend `#/components/schemas/` to typebox references while building schema

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -652,24 +652,10 @@ export const enumToOpenApi = <
 			return toRef(schema.$ref) as any;
 	}
 
-	const schema = _schema as OpenAPIV3.SchemaObject
+	const schema: any = Array.isArray(_schema) ? [..._schema] : { ..._schema }
 
-	if (schema.type === 'object' && schema.properties) {
-		const properties: Record<string, unknown> = {}
-		for (const [key, value] of Object.entries(schema.properties))
-			properties[key] = enumToOpenApi(value)
-
-		return {
-			...schema,
-			properties
-		} as T
-	}
-
-	if (schema.type === 'array' && schema.items)
-		return {
-			...schema,
-			items: enumToOpenApi(schema.items)
-		} as T
+	for (const [key, value] of Object.entries(schema))
+		schema[key] = enumToOpenApi(value as any)
 
 	return schema as T
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -612,7 +612,10 @@ export const unwrapSchema = (
 }
 
 /**
- * Convert TypeBox enum-like Union schemas to OpenAPI enum schemas
+ * Converts TypeBox enum-like Union schemas to OpenAPI enum schemas.
+ *
+ * Also prepends `#/components/schemas/` to TypeBox t.Ref instances
+ * if the string is not already present.
  *
  * Otherwise, return the schema as is
  */
@@ -644,6 +647,9 @@ export const enumToOpenApi = <
 				type: 'string',
 				enum: schema.anyOf.map((item) => item.const)
 			} as any
+
+		if (schema[Kind] === 'Ref' && schema.$ref)
+			return toRef(schema.$ref) as any;
 	}
 
 	const schema = _schema as OpenAPIV3.SchemaObject


### PR DESCRIPTION
This PR fixes the bug described in #310 by crawling the TypeBox schema during the `enumToOpenApi` step, finding instances of references, and calling `toRef` on them. Absolutely love what you guys are doing, keep up the great work!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenAPI schema generation to better handle enum-like union schemas and schema references, returning normalized references where appropriate.
  * Expanded recursive conversion to traverse all schema properties for more consistent translation, improving compatibility and reducing edge-case mismatches in generated API schemas.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia-openapi/pull/337)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->