### PR TITLE
feat(openapi): resolve registered models as $ref pointers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
         "effect": "^3.21.2",
-        "elysia": "1.4.19",
+        "elysia": "1.4.28",
         "eslint": "9.6.0",
         "openapi-types": "^12.1.3",
         "tsup": "^8.5.1",
@@ -163,7 +163,7 @@
 
     "@scalar/types": ["@scalar/types@0.2.16", "", { "dependencies": { "@scalar/openapi-types": "0.3.7", "nanoid": "5.1.5", "zod": "3.24.1" } }, "sha512-XWff9jWfYaj6q3ww94x66S6Q58u/3kA1sDOUhLAwb9va7r58bzk3NRwLOkEEdJmyEns1MEJAM53mY8KRWX6elA=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@sinclair/typemap": ["@sinclair/typemap@0.10.1", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.30", "valibot": "^1.0.0", "zod": "^3.24.1" } }, "sha512-UXR0fhu/n3c9B6lB+SLI5t1eVpt9i9CdDrp2TajRe3LbKiUhCTZN2kSfJhjPnpc3I59jMRIhgew7+0HlMi08mg=="],
 
@@ -241,7 +241,7 @@
 
     "effect": ["effect@3.21.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg=="],
 
-    "elysia": ["elysia@1.4.19", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "0.2.5", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-DZb9y8FnWyX5IuqY44SvqAV0DjJ15NeCWHrLdgXrKgTPDPsl3VNwWHqrEr9bmnOCpg1vh6QUvAX/tcxNj88jLA=="],
+    "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -263,7 +263,7 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "exact-mirror": ["exact-mirror@0.2.5", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-u8Wu2lO8nio5lKSJubOydsdNtQmH8ENba5m0nbQYmTvsjksXKYIS1nSShdDlO8Uem+kbo+N6eD5I03cpZ+QsRQ=="],
+    "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
         "effect": "^3.21.2",
-        "elysia": "1.4.19",
+        "elysia": "1.4.28",
         "eslint": "9.6.0",
         "openapi-types": "^12.1.3",
         "tsup": "^8.5.1",

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -668,6 +668,105 @@ export const enumToOpenApi = <
 	return schema as T
 }
 
+// ============================================================================
+// Model Reference Resolution
+// ============================================================================
+
+const buildModelRefMap = (
+	definitions: Record<string, unknown> | undefined
+) => {
+	const map = new Map<unknown, string>()
+
+	if (definitions)
+		for (const [name, schema] of Object.entries(definitions))
+			map.set(schema, name)
+
+	return map
+}
+
+const deepEqual = (a: unknown, b: unknown): boolean => {
+	if (a === b) return true
+	if (a === null || b === null) return false
+	if (typeof a !== typeof b || typeof a !== 'object') return false
+
+	if (Array.isArray(a))
+		return Array.isArray(b)
+			&& a.length === b.length
+			&& a.every((v, i) => deepEqual(v, b[i]))
+
+	const aObj = a as Record<string, unknown>
+	const bObj = b as Record<string, unknown>
+	const aKeys = Object.keys(aObj)
+	const bKeys = Object.keys(bObj)
+
+	return aKeys.length === bKeys.length
+		&& aKeys.every((k) => deepEqual(aObj[k], bObj[k]))
+}
+
+const stripSchemaMeta = (schema: Record<string, unknown>) => {
+	const { $schema: _s, $id: _i, ...rest } = schema
+	return rest
+}
+
+/**
+ * Walk paths and replace inline schemas matching a registered model
+ * with { $ref } pointers. Handles nested cases like z.array(Model).
+ */
+const resolveNestedModelRefs = (spec: {
+	components: { schemas: Record<string, unknown> }
+	paths: Record<string, unknown>
+}) => {
+	const entries = Object.entries(spec.components.schemas)
+	if (!entries.length) return
+
+	const models = entries.map(([name, raw]) => {
+		const schema = stripSchemaMeta(raw as Record<string, unknown>)
+		spec.components.schemas[name] = schema
+		return { name, schema }
+	})
+
+	const tryReplace = (
+		node: unknown,
+		parent: Record<string, unknown> | unknown[],
+		key: string | number
+	): boolean => {
+		if (!node || typeof node !== 'object') return false
+
+		const obj = node as Record<string, unknown>
+		if ('$ref' in obj) return false
+
+		const cleaned = stripSchemaMeta(obj)
+
+		for (const model of models)
+			if (deepEqual(cleaned, model.schema)) {
+				(parent as Record<string | number, unknown>)[key] =
+					{ $ref: `#/components/schemas/${model.name}` }
+				return true
+			}
+
+		return false
+	}
+
+	const walk = (node: unknown) => {
+		if (!node || typeof node !== 'object') return
+
+		if (Array.isArray(node)) {
+			for (let i = 0; i < node.length; i++)
+				if (!tryReplace(node[i], node, i))
+					walk(node[i])
+			return
+		}
+
+		const obj = node as Record<string, unknown>
+
+		for (const key of Object.keys(obj))
+			if (!tryReplace(obj[key], obj, key))
+				walk(obj[key])
+	}
+
+	walk(spec.paths)
+}
+
 /**
  * Converts Elysia routes to OpenAPI 3.0.3 paths schema
  * @param routes Array of Elysia route objects
@@ -696,6 +795,7 @@ export function toOpenAPISchema(
 	const paths: OpenAPIV3.PathsObject = Object.create(null)
 	// @ts-ignore
 	const definitions = app.getGlobalDefinitions?.().type
+	const modelRefMap = buildModelRefMap(definitions)
 
 	if (references) {
 		if (!Array.isArray(references)) references = [references]
@@ -986,6 +1086,20 @@ export function toOpenAPISchema(
 				!(hooks.response as any)['~standard']
 			) {
 				for (let [status, schema] of Object.entries(hooks.response)) {
+					const modelName = modelRefMap.get(schema)
+
+					if (modelName) {
+						operation.responses[status] = {
+							description: `Response for status ${status}`,
+							content: {
+								'application/json': {
+									schema: { $ref: `#/components/schemas/${modelName}` }
+								}
+							}
+						}
+						continue
+					}
+
 					const response = unwrapSchema(schema, vendors, 'output')
 
 					if (!response) continue
@@ -1019,43 +1133,56 @@ export function toOpenAPISchema(
 					}
 				}
 			} else {
-				const response = unwrapSchema(
-					hooks.response as any,
-					vendors,
-					'output'
-				)
+				const modelName = modelRefMap.get(hooks.response)
 
-				if (response) {
-					// @ts-ignore
-					const {
-						type: _type,
-						description,
-						...options
-					} = unwrapReference(response, definitions)
-					const type = _type as string | undefined
-
-					// It's a single schema, default to 200
+				if (modelName) {
 					operation.responses['200'] = {
-						description: description ?? `Response for status 200`,
-						content:
-							type === 'void' ||
-							type === 'null' ||
-							type === 'undefined'
-								? ({ type, description } as any)
-								: type === 'string' ||
-									  type === 'number' ||
-									  type === 'integer' ||
-									  type === 'boolean'
-									? {
-											'text/plain': {
-												schema: response
+						description: 'Response for status 200',
+						content: {
+							'application/json': {
+								schema: { $ref: `#/components/schemas/${modelName}` }
+							}
+						}
+					}
+				} else {
+					const response = unwrapSchema(
+						hooks.response as any,
+						vendors,
+						'output'
+					)
+
+					if (response) {
+						// @ts-ignore
+						const {
+							type: _type,
+							description,
+							...options
+						} = unwrapReference(response, definitions)
+						const type = _type as string | undefined
+
+						// It's a single schema, default to 200
+						operation.responses['200'] = {
+							description: description ?? `Response for status 200`,
+							content:
+								type === 'void' ||
+								type === 'null' ||
+								type === 'undefined'
+									? ({ type, description } as any)
+									: type === 'string' ||
+										  type === 'number' ||
+										  type === 'integer' ||
+										  type === 'boolean'
+										? {
+												'text/plain': {
+													schema: response
+												}
 											}
-										}
-									: {
-											'application/json': {
-												schema: response
+										: {
+												'application/json': {
+													schema: response
+												}
 											}
-										}
+						}
 					}
 				}
 			}
@@ -1109,12 +1236,16 @@ export function toOpenAPISchema(
 			if (jsonSchema) schemas[name] = jsonSchema
 		}
 
-	return {
+	const result = {
 		components: {
 			schemas
 		},
 		paths
 	} satisfies Pick<OpenAPIV3.Document, 'paths' | 'components'>
+
+	resolveNestedModelRefs(result)
+
+	return result
 }
 
 export const withHeaders = (schema: TSchema, headers: TProperties) =>

--- a/test/model-refs.test.ts
+++ b/test/model-refs.test.ts
@@ -1,0 +1,140 @@
+import { Elysia, t } from 'elysia'
+import { openapi } from '../src'
+
+import { describe, expect, it } from 'bun:test'
+import z from 'zod'
+
+const req = (path: string) => new Request(`http://localhost${path}`)
+
+const getSpec = async (app: Elysia<any, any, any, any, any, any, any, any>) => {
+	await app.modules
+	return app.handle(req('/openapi/json')).then((r) => r.json())
+}
+
+describe('Model Reference Resolution', () => {
+	it('replaces direct model usage with $ref (TypeBox)', async () => {
+		const app = new Elysia()
+			.use(openapi())
+			.model({ User: t.Object({ id: t.String(), name: t.String() }) })
+			.get('/user', () => ({}), {
+				response: t.Object({ id: t.String(), name: t.String() })
+			})
+
+		const spec = await getSpec(app)
+		const schema = spec.paths['/user'].get.responses['200'].content['application/json'].schema
+
+		expect(schema).toEqual({ $ref: '#/components/schemas/User' })
+	})
+
+	it('replaces direct model usage with $ref (Zod)', async () => {
+		const User = z.object({ id: z.string(), name: z.string() })
+
+		const app = new Elysia()
+			.use(openapi({ mapJsonSchema: { zod: z.toJSONSchema } }))
+			.model({ User })
+			.get('/user', () => ({}), { response: User })
+
+		const spec = await getSpec(app)
+		const schema = spec.paths['/user'].get.responses['200'].content['application/json'].schema
+
+		expect(schema).toEqual({ $ref: '#/components/schemas/User' })
+	})
+
+	it('replaces nested model inside z.array() with $ref', async () => {
+		const User = z.object({ id: z.string(), name: z.string() })
+
+		const app = new Elysia()
+			.use(openapi({ mapJsonSchema: { zod: z.toJSONSchema } }))
+			.model({ User })
+			.get('/users', () => [], { response: z.array(User) })
+
+		const spec = await getSpec(app)
+		const schema = spec.paths['/users'].get.responses['200'].content['application/json'].schema
+
+		expect(schema.type).toBe('array')
+		expect(schema.items).toEqual({ $ref: '#/components/schemas/User' })
+	})
+
+	it('replaces nested model inside t.Array() with $ref', async () => {
+		const User = t.Object({ id: t.String(), name: t.String() })
+
+		const app = new Elysia()
+			.use(openapi())
+			.model({ User })
+			.get('/users', () => [], { response: t.Array(User) })
+
+		const spec = await getSpec(app)
+		const schema = spec.paths['/users'].get.responses['200'].content['application/json'].schema
+
+		expect(schema.type).toBe('array')
+		expect(schema.items).toEqual({ $ref: '#/components/schemas/User' })
+	})
+
+	it('replaces model in status code map responses', async () => {
+		const User = z.object({ id: z.string(), name: z.string() })
+
+		const app = new Elysia()
+			.use(openapi({ mapJsonSchema: { zod: z.toJSONSchema } }))
+			.model({ User })
+			.get('/user', () => ({}), {
+				response: { 200: User, 404: z.string() }
+			})
+
+		const spec = await getSpec(app)
+		const ok = spec.paths['/user'].get.responses['200'].content['application/json'].schema
+		const notFound = spec.paths['/user'].get.responses['404'].content['text/plain'].schema
+
+		expect(ok).toEqual({ $ref: '#/components/schemas/User' })
+		expect(notFound.type).toBe('string')
+	})
+
+	it('does not replace schemas that do not match a model', async () => {
+		const User = z.object({ id: z.string(), name: z.string() })
+		const Other = z.object({ foo: z.string(), bar: z.number() })
+
+		const app = new Elysia()
+			.use(openapi({ mapJsonSchema: { zod: z.toJSONSchema } }))
+			.model({ User })
+			.get('/other', () => ({}), { response: Other })
+
+		const spec = await getSpec(app)
+		const schema = spec.paths['/other'].get.responses['200'].content['application/json'].schema
+
+		expect(schema.$ref).toBeUndefined()
+		expect(schema.type).toBe('object')
+		expect(schema.properties.foo).toBeDefined()
+	})
+
+	it('registers models in components/schemas', async () => {
+		const User = z.object({ id: z.string(), name: z.string() })
+
+		const app = new Elysia()
+			.use(openapi({ mapJsonSchema: { zod: z.toJSONSchema } }))
+			.model({ User })
+			.get('/user', () => ({}), { response: User })
+
+		const spec = await getSpec(app)
+
+		expect(spec.components.schemas.User).toBeDefined()
+		expect(spec.components.schemas.User.type).toBe('object')
+		expect(spec.components.schemas.User.properties.id.type).toBe('string')
+	})
+
+	it('handles multiple models without cross-contamination', async () => {
+		const User = z.object({ id: z.string(), name: z.string() })
+		const Post = z.object({ id: z.string(), title: z.string(), body: z.string() })
+
+		const app = new Elysia()
+			.use(openapi({ mapJsonSchema: { zod: z.toJSONSchema } }))
+			.model({ User, Post })
+			.get('/user', () => ({}), { response: User })
+			.get('/post', () => ({}), { response: Post })
+
+		const spec = await getSpec(app)
+
+		expect(spec.paths['/user'].get.responses['200'].content['application/json'].schema)
+			.toEqual({ $ref: '#/components/schemas/User' })
+		expect(spec.paths['/post'].get.responses['200'].content['application/json'].schema)
+			.toEqual({ $ref: '#/components/schemas/Post' })
+	})
+})


### PR DESCRIPTION
Schemas registered via .model() are now matched against inline schemas
in route definitions and replaced with $ref pointers to
components/schemas. This reduces spec size and improves readability.

Direct model usage (e.g. response: User) is matched by object identity
on the raw schema before JSON Schema conversion. Nested usage (e.g.
response: z.array(User)) is matched by deep equality on the converted
JSON Schema output.

Works with all Standard Schema validators (Zod, TypeBox, Valibot, etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI specification generation now automatically resolves and consolidates model schemas, converting inline definitions to component schema references for improved documentation cleanliness and standardized API representations.

* **Tests**
  * Comprehensive test coverage added for model reference resolution, including TypeBox and Zod schemas, nested structures, and status-code-specific response mappings.

* **Chores**
  * Updated elysia development dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia-openapi/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->