### PR TITLE
fix: document ArkType predicate/morph keywords instead of dropping them (elysiajs/elysia#1844)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@scalar/types": "^0.2.16",
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
+        "arktype": "^2.2.1",
         "effect": "^3.21.2",
         "elysia": "1.4.19",
         "eslint": "9.6.0",
@@ -30,6 +31,10 @@
     "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
 
     "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@12.1.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "14.0.1", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng=="],
+
+    "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
+
+    "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
 
@@ -198,6 +203,10 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "arkregex": ["arkregex@0.0.6", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-9mvuMKQuibfWhBrsNYhsKhNb6k9oEHoAJ/FvDiqe8h+E9Siwe0/cro1WVOGgpajXQ9ZHd24yCOf2k35Q/QqUQw=="],
+
+    "arktype": ["arktype@2.2.1", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.6" } }, "sha512-CWPJxNoSxrS+NYGB3ufwc/blFonESEW5vBQyYPVS0rf4STu8VWoAWfKJSl5vVVm56h4yxpwbODeYwy6XFKvojA=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "@scalar/types": "^0.2.16",
         "@sinclair/typemap": "^0.10.1",
         "@types/bun": "1.2.20",
+        "arktype": "^2.2.1",
         "effect": "^3.21.2",
         "elysia": "1.4.19",
         "eslint": "9.6.0",

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -537,6 +537,27 @@ export const unwrapSchema = (
 		)
 			return enumToOpenApi(mapJsonSchema[vendor](schema))
 
+		// ============================================================================
+		// ArkType toJsonSchema fallback (predicates, morphs, Date, etc.)
+		// ============================================================================
+		if (vendor === 'arktype')
+			return enumToOpenApi(
+				// @ts-ignore
+				schema?.toJsonSchema?.({
+					fallback: {
+						// real Date types -> string with date-time format
+						date: (ctx: { base: Record<string, unknown> }) => ({
+							...ctx.base,
+							type: 'string',
+							format: 'date-time'
+						}),
+						// anything else unrepresentable -> keep the base type
+						default: (ctx: { base: Record<string, unknown> }) =>
+							ctx.base
+					}
+				})
+			)
+
 		// @ts-ignore
 		if (schema['~standard']?.jsonSchema?.[io])
 			// @ts-ignore
@@ -597,10 +618,6 @@ export const unwrapSchema = (
 				console.warn(warnings.effect)
 				break
 		}
-
-		if (vendor === 'arktype')
-			// @ts-ignore
-			return enumToOpenApi(schema?.toJsonSchema?.())
 
 		return enumToOpenApi(
 			// @ts-ignore

--- a/test/openapi/to-openapi-schema.test.ts
+++ b/test/openapi/to-openapi-schema.test.ts
@@ -3,6 +3,7 @@ import { AnyElysia, Elysia, t } from 'elysia'
 
 import { toOpenAPISchema } from '../../src/openapi'
 import { z } from 'zod'
+import { type } from 'arktype'
 
 const is = <T extends AnyElysia>(
 	app: T,
@@ -1275,5 +1276,130 @@ describe('OpenAPI > toOpenAPISchema', () => {
 				}
 			}
 		})
+	})
+})
+
+describe('OpenAPI > ArkType', () => {
+	// ArkType emits the JSON Schema `$schema` dialect on each converted schema.
+	const $schema = 'https://json-schema.org/draft/2020-12/schema'
+
+	// Body schemas are mirrored across every accepted content type.
+	const body = (s: Record<string, unknown>) => ({
+		content: {
+			'application/json': { schema: s },
+			'application/x-www-form-urlencoded': { schema: s },
+			'multipart/form-data': { schema: s }
+		},
+		required: true
+	})
+
+	const doc = (app: AnyElysia) =>
+		JSON.parse(JSON.stringify(toOpenAPISchema(app)))
+
+	// https://github.com/elysiajs/elysia/issues/1844
+	it('degrades a predicate (string.date) instead of dropping the schema', () => {
+		const app = new Elysia().post('/bug', () => 'ok', {
+			body: type({ date: 'string.date' })
+		})
+
+		is(app, {
+			components: { schemas: {} },
+			paths: {
+				'/bug': {
+					post: {
+						operationId: 'postBug',
+						requestBody: body({
+							$schema,
+							type: 'object',
+							properties: { date: { type: 'string' } },
+							required: ['date']
+						})
+					}
+				}
+			}
+		})
+	})
+
+	it('maps a Date to string/date-time', () => {
+		const app = new Elysia().post('/at', () => 'ok', {
+			body: type({ at: 'Date' })
+		})
+
+		is(app, {
+			components: { schemas: {} },
+			paths: {
+				'/at': {
+					post: {
+						operationId: 'postAt',
+						requestBody: body({
+							$schema,
+							type: 'object',
+							properties: {
+								at: { type: 'string', format: 'date-time' }
+							},
+							required: ['at']
+						})
+					}
+				}
+			}
+		})
+	})
+
+	it('leaves a predicate-free schema unchanged', () => {
+		const app = new Elysia().post('/plain', () => 'ok', {
+			body: type({ name: 'string', age: 'number' })
+		})
+
+		expect(
+			doc(app).paths['/plain'].post.requestBody.content[
+				'application/json'
+			].schema
+		).toEqual({
+			$schema,
+			type: 'object',
+			properties: { name: { type: 'string' }, age: { type: 'number' } },
+			required: ['age', 'name']
+		})
+	})
+
+	// Morphs (e.g. `string.date.parse`) previously threw `code: "morph"` and
+	// dropped the schema; the `default` fallback degrades them to the base type.
+	it('degrades a morph (string.date.parse) instead of dropping the schema', () => {
+		const app = new Elysia().post('/morph', () => 'ok', {
+			body: type({ when: 'string.date.parse' })
+		})
+
+		const op = doc(app).paths['/morph'].post
+
+		expect(op.requestBody).toBeDefined()
+		expect(
+			op.requestBody.content['application/json'].schema.properties.when
+		).toEqual({ type: 'string' })
+	})
+
+	it('lets a user-supplied mapJsonSchema.arktype override win', () => {
+		const app = new Elysia().post('/override', () => 'ok', {
+			body: type({ date: 'string.date' })
+		})
+
+		const override = {
+			type: 'object',
+			properties: { date: { type: 'string', format: 'overridden' } },
+			required: ['date']
+		}
+
+		const result = JSON.parse(
+			JSON.stringify(
+				toOpenAPISchema(app, undefined, undefined, {
+					arktype: () => override
+				})
+			)
+		)
+
+		expect(
+			result.paths['/override'].post.requestBody.content[
+				'application/json'
+			].schema
+		).toEqual(override)
 	})
 })


### PR DESCRIPTION
## What does this PR do?

Adds an explicit `arktype` branch to `unwrapSchema` (`src/openapi.ts`) before the Standard Schema path that calls `toJsonSchema({ fallback: { date, default } })`. Predicates (e.g. `string.date`'s `isParsableDate`) and morphs (e.g. `string.date.parse`) now degrade to their base type instead of throwing, and a real `Date` maps to `{ "type": "string", "format": "date-time" }`. Also removes the old unreachable `arktype` branch lower in the function that called `toJsonSchema()` with no fallback.

## Why was this PR needed?

Fixes elysiajs/elysia#1844. ArkType's `string.date` compiles to `string` + a runtime `isParsableDate` predicate. When the plugin converts this to JSON Schema, ArkType throws a `ToJsonSchemaError` (`code: "predicate"`) because predicates have no JSON Schema equivalent. The surrounding `try/catch` (added in [8a775ca](https://github.com/elysiajs/elysia-openapi/commit/8a775ca3d2454b187377a889094ca57e2259fd00)) swallows the error and returns `undefined`, silently dropping the route's `requestBody` from the docs while `/openapi/json` still returns `200`.

The Standard Schema path (`schema['~standard'].jsonSchema[...]`) never forwards a `fallback` to `toJsonSchema()`, so it always throws on predicate- and morph-bearing types. The fix handles ArkType before that path using the `{ date, default }` fallback shape ArkType's [own docs](https://arktype.io/docs/blog/2.2#configurable-tojsonschema) recommend. Predicate-free schemas and user-supplied `mapJsonSchema.arktype` overrides are unaffected.

## Acceptance Criteria

- [x] Tests added for new/changed behavior: new `OpenAPI > ArkType` block in `test/openapi/to-openapi-schema.test.ts` (5 tests include predicate degrades, `Date` → date-time, predicate-free schema unchanged, morph degrades, user `mapJsonSchema.arktype` override still works)
- [x] All tests passing: `bun run test` green; `bun run build` compiles cleanly
- [x] Follows project style guide
- [x] No breaking changes introduced (only adds handling for schemas that previously threw and were dropped; working schemas are untouched)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ArkType schemas in OpenAPI generation.
  * Date values from ArkType now appear as `string` with `format: date-time` in generated schemas.

* **Bug Fixes**
  * Improved schema conversion so ArkType inputs no longer get dropped from request bodies.
  * ArkType predicate and morph types now fall back to usable OpenAPI-compatible schemas instead of failing conversion.
  * User-provided ArkType schema mapping overrides are now respected in generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->